### PR TITLE
should handle i18n deprecation warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,6 @@ module WetapApi
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.i18n.enforce_available_locales = false
   end
 end


### PR DESCRIPTION
## motivation

```
$ be rake spec
[deprecated] I18n.enforce_available_locales will default to true in the future. 
If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false
to avoid this message.
```
## needs review

My guess is that since the web services has no public UI features, we do not need to worry about locales.
- [x] should `config.i18n.enforce_available_locales` be `true` or `false`?

http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
