### PR TITLE
refactor WaterFountain factory to provide properties "longitude" and "latitude"

### DIFF
--- a/app/assets/angular/controllers/water-fountain-controller.js
+++ b/app/assets/angular/controllers/water-fountain-controller.js
@@ -18,7 +18,6 @@ weTap.controller('WaterFountainIndexController', ['$scope', 'WaterFountain', fun
 weTap.controller('WaterFountainCreateController', ['$scope', '$location', 'WaterFountain', function ($scope, $location, WaterFountain) {
   $scope.save = function () {
     // Create the waterFountain object to send to the back-end
-    // Indentation here is to clarify the components. Feel free to adjust to suit your OCD tendencies :-)
     var waterFountain = new WaterFountain({
       water_fountain: {
         location: {
@@ -49,8 +48,8 @@ weTap.controller('WaterFountainShowController', ['$scope', 'WaterFountain', '$ro
   $scope.$watch('waterFountain.id', function () {
     if ($scope.waterFountain.$resolved) {
       $scope.sites.push({
-        latitude: $scope.waterFountain.location.coordinates[1],
-        longitude: $scope.waterFountain.location.coordinates[0],
+        latitude: $scope.waterFountain.latitude,
+        longitude: $scope.waterFountain.longitude,
         options: {title: "Fountain: " + $scope.waterFountain.id}
       });
       $scope.map = {
@@ -62,8 +61,8 @@ weTap.controller('WaterFountainShowController', ['$scope', 'WaterFountain', '$ro
           minZoom: 3
         },
         center: {
-          latitude: $scope.waterFountain.location.coordinates[1],
-          longitude: $scope.waterFountain.location.coordinates[0]
+          latitude: $scope.waterFountain.latitude,
+          longitude: $scope.waterFountain.longitude
         },
         zoom: 18
       };

--- a/app/assets/angular/services/models.js
+++ b/app/assets/angular/services/models.js
@@ -6,13 +6,14 @@ weTap.factory('WaterFountain', ['$resource', function ($resource) {
 
   var waterFountainFactory = $resource('/water_fountains/:id.json', {id: '@id'});
 
-  waterFountainFactory.prototype.longitude = function () {
-    if (angular.isDefined(this.location)) {return this.location.coordinates[0];}
-  };
-
-  waterFountainFactory.prototype.latitude = function () {
-    if (angular.isDefined(this.location)) {return this.location.coordinates[1];}
-  };
+  // define properties to allow the app to use, for example, wf.latitude instead of wf.location.coordinates[1]
+  _.each(["longitude", "latitude"], function(coordinate, ix) {
+      Object.defineProperty(waterFountainFactory.prototype, coordinate, {
+        get: function () {return this.location.coordinates[ix];},
+        enumerable : true,
+        configurable : true
+      });
+    });
 
   return waterFountainFactory;
 }]);

--- a/app/assets/angular/templates/index.html
+++ b/app/assets/angular/templates/index.html
@@ -19,8 +19,8 @@
         </tr>
         <tr ng-repeat="item in items">
           <td>{{item.id}}</td>
-          <td>{{item.longitude()}}</td>
-          <td>{{item.latitude()}}</td>
+          <td>{{item.longitude}}</td>
+          <td>{{item.latitude}}</td>
           <td>
             <a href="#/water_fountain/{{item.id}}" class="btn btn-small">Details</a>
             <a ng-click="destroy($index)" href="" class="btn btn-small">Delete</a>


### PR DESCRIPTION
uses defineProperty to simplify access to these values - instead of saying "waterFountain.location.coordinates[1]", you can now simply say "waterFountain.latitude"
