### PR TITLE
remove ruby-filemagic since heroku can't install it.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'devise'
 
 # file attachments
 gem 'paperclip'
-gem 'ruby-filemagic'
 
 # Store file attachments on s3
 gem 'aws-sdk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,6 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    ruby-filemagic (0.6.0)
     safe_yaml (1.0.3)
     sass (3.2.19)
     sass-rails (4.0.3)
@@ -221,7 +220,6 @@ DEPENDENCIES
   rails (= 4.0.3)
   rgeo-geojson
   rspec-rails (~> 2.14.2)
-  ruby-filemagic
   sass-rails (~> 4.0.0)
   sdoc
   uglifier (>= 1.3.0)

--- a/app/controllers/water_fountains_controller.rb
+++ b/app/controllers/water_fountains_controller.rb
@@ -36,7 +36,15 @@ class WaterFountainsController < ApplicationController
       # will be nothing left to read. Giving us the appearance of an empty file.
       decoded_image_file.rewind
 
-      mime_type = FileMagic.new(FileMagic::MAGIC_MIME).file(decoded_image_file.path)
+      # assert the mime-type is jpeg, if the actual file type doesn't match, the
+      # controller will blow up.
+      mime_type = 'image/jpeg'
+
+      # Previously we were ascertaining the mimetype from the contents of the
+      # file using the ruby-filemagic gem but the FileMagic gem does not
+      # install on Heroku. - mjk 2014/5/30
+      # mime_type = FileMagic.new(FileMagic::MAGIC_MIME).file(decoded_image_file.path)
+     
 
       # create a new uploaded file
       uploaded_file = ActionDispatch::Http::UploadedFile.new(

--- a/provisioning/base.yml
+++ b/provisioning/base.yml
@@ -39,7 +39,6 @@
         - vim
         - nodejs
         - imagemagick # paperclip gem resizes images before uploading
-        - libmagic-dev # ruby-filemagic gem does mimetype lookups
         - libqtwebkit-dev # for capybara headless webkit
         - libqt4-dev # for capybara headless webkit
         - xvfb # for capybara headless webkit


### PR DESCRIPTION
filemagic is just ruby bindings to a library - libmagick. This library
isn't installed on heroku, nor do we have the ability to install it on
heroku. So we're going to make the assumption that only jpeg will be
sent to the api.
