### PR TITLE
halt VM after build

### DIFF
--- a/script/ci
+++ b/script/ci
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 vagrant halt
 vagrant box update
 vagrant up --provision
@@ -11,3 +12,10 @@ cd /vagrant
 bundle exec rake db:test:prepare
 script/ci-rspec &&
 script/ci-cucumber
+END
+
+BUILD_SUCCESS=$?
+
+# Halt VM to avoid conflicts with other builds
+vagrant halt
+exit $BUILD_SUCCESS


### PR DESCRIPTION
We have multiple VM's running on CI, So there is port contention across different VM's. We need to make sure we're halting the VM after the build so that we don't interfere with other builds.
