### PR TITLE
Bug/remove confirmable

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ActiveRecord::Base
   TEMP_EMAIL = 'change@me.com'
   TEMP_EMAIL_REGEX = /change@me.com/
 
-  devise :database_authenticatable, :registerable, :confirmable, :lockable,
+  devise :database_authenticatable, :registerable, :lockable,
     :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
   validates_format_of :email, :without => TEMP_EMAIL_REGEX, on: :update
@@ -35,7 +35,6 @@ class User < ActiveRecord::Base
           email: email ? email : TEMP_EMAIL,
           password: Devise.friendly_token[0,20]
         )
-        user.skip_confirmation!
         user.save!
       end
     end


### PR DESCRIPTION
This branch is based on https://github.com/wetap/wetap-api/pull/19 so merge that first!  Take a look at a diff of actual changes [here](https://github.com/wetap/wetap-api/compare/feature/style_login_pages...bug/remove_confirmable)

This removes confirmation of the user accounts. The motivation is that the API is not properly integrated into what [devise confirmable](http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/Confirmable) provides. So wetap functionality (fountain creation etc) _works_ even though the User is in an unconfirmed state. 

The solution is to drop `:confirmable` from the user model and implement it as a proper feature further down the road.
