### PR TITLE
do not display logo on 3.5 inch phones

### DIFF
--- a/app/assets/stylesheets/iphone.css.scss.erb
+++ b/app/assets/stylesheets/iphone.css.scss.erb
@@ -3,6 +3,11 @@ $wetap-light-blue: rgb(59, 185, 233);
 $wetap-highlight-blue: rgb(157, 220, 244);
 $wetap-dark-blue: rgb(0, 53, 109);
 
+@media only screen and (device-height: 480px){
+  div#logo img{
+    display: none;
+  }
+}
 
 
 @media only screen and (max-device-width: 480px) {

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,4 @@
-= render("devise/shared/logo_header", title: "Sign up", sub_title: link_to("Or, Sign in", new_session_path(resource_name), class: "path-alternative"))
+= render("devise/shared/logo_header", title: "Sign up", sub_title: "Create an account")
 
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = devise_error_messages!

--- a/app/views/devise/sessions/new.haml
+++ b/app/views/devise/sessions/new.haml
@@ -1,4 +1,4 @@
-= render("devise/shared/logo_header", title: "Sign in", sub_title: link_to("Or, create an account", new_registration_path(resource_name), class: "path-alternative"))
+= render("devise/shared/logo_header", title: "Sign in", sub_title: "Sign in to your account")
 
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   %div

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,4 +1,13 @@
 <div id="devise-links">
+
+  <%- if controller_name == 'registrations' %>
+    <%= link_to("Sign in to your account", new_session_path(resource_name)) %>
+  <% end %>
+
+  <%- if controller_name == 'sessions' %>
+    <%= link_to("Create an account", new_registration_path(resource_name)) %>
+  <% end %>
+
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
     <%= link_to "Forgot password", new_password_path(resource_name) %><br />
   <% end -%>

--- a/app/views/devise/shared/_logo_header.html.haml
+++ b/app/views/devise/shared/_logo_header.html.haml
@@ -6,4 +6,5 @@
   #logo.visible-phone
     = image_tag("wetap/app-icon-512x512.png")
     %br
-    = sub_title
+    %span.path-alternative
+      = sub_title


### PR DESCRIPTION
This PR reflects feedback from evelyn on https://www.pivotaltracker.com/story/show/67127028  Style Account login screens-- basically just rearranging text.

The one catch here is that on a 3.5 inch phone some of the content drops off the phone's display. This drops the wetap logo for those 3.5inch sized phones.
