### PR TITLE
Style text login input fields

### DIFF
--- a/app/assets/stylesheets/iphone.css.scss.erb
+++ b/app/assets/stylesheets/iphone.css.scss.erb
@@ -26,7 +26,7 @@ $wetap-dark-blue: rgb(0, 53, 109);
   }
 
   input{
-    font-size: 1.2em;
+    font-size: 1.3em;
   }
 
   input[type="email"], input[type="password"]{


### PR DESCRIPTION
Fixes "email address input field is red". [1]

Increases the font-size to 1.3em for inputs.  Previously the email and password font-size was 1.0em and button text was 1.2.

I was having a hard time reading the text on the phone.
- [1] https://www.pivotaltracker.com/story/show/77457262
#### Todo
- [x] @kellierife needs design review

The first image in both previews are the new settings.
#### Previews
##### Email Font Size
# 
# ![2014-09-02_10-51-31](https://cloud.githubusercontent.com/assets/466104/4116144/93e9e9d6-3281-11e4-882a-a657a3393d60.png)
##### Button Font Size
# 
# ![2014-09-02_11-03-21](https://cloud.githubusercontent.com/assets/466104/4116154/b697daa6-3281-11e4-84da-4374b376419e.png)
