### PR TITLE
Sets flash message timeout to 15s

### DIFF
--- a/app/assets/javascripts/hide_flash.js.coffee
+++ b/app/assets/javascripts/hide_flash.js.coffee
@@ -3,4 +3,4 @@ $ ->
     $(".alert").fadeOut()
   $(".alert").bind 'click', (ev) =>
     $(".alert").fadeOut()
-  setTimeout flashCallback, 9000
+  setTimeout flashCallback, 15000


### PR DESCRIPTION
Fixes "Reset password instructions disappear too quickly." [1]

@svevang This changes the global timeout, no?  Is that going to be a problem elsewhere?
- [1] https://www.pivotaltracker.com/story/show/77554636
