### PR TITLE
Suppresses 'TODO' exposes auth tokens

### DIFF
--- a/app/views/auth_token_pairs/me.haml
+++ b/app/views/auth_token_pairs/me.haml
@@ -1,8 +1,5 @@
 #message
   - if current_user.present?
-    -# TODO:  Pick up your wetap auth credentials here.
-    -# = "Public token: #{current_user.public_token}"
-    -# = "Private token: #{current_user.private_token}"
     :javascript
       #{render 'auth_token_pair.js', public_token: current_user.public_token}
   - else


### PR DESCRIPTION
@svevang 

I sometimes see this message when there is a problem logging in.

I _believe_ I am also seeing this message as an artifact when the Login ==> Add Fountain animations occurs; it manifests as a brief white ellipsis (...).

Is it safe to remove it?
# 

![2014-09-02_11-29-20](https://cloud.githubusercontent.com/assets/466104/4116845/14997e9a-328a-11e4-9afc-74ad90da2c1a.png)
# 
