### PR TITLE
After CI, halt and destroy vagrant

### DIFF
--- a/script/ci
+++ b/script/ci
@@ -30,4 +30,5 @@ BUILD_SUCCESS=$?
 
 # Halt VM to avoid conflicts with other builds
 vagrant halt
+vagrant destroy --force
 exit $BUILD_SUCCESS


### PR DESCRIPTION
In addition to halting, should we destroy vagrant as well?

In the context of: "jenkins disk full". [1]

https://www.pivotaltracker.com/story/show/78043342
